### PR TITLE
Adjusted header markup to follow proper hierarchical structure 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
+########################
 Firefox Test Engineering
-========================
+########################
 A tutorial on some of the basic things you'd want to know when
 contributing to `Firefox Test Engineering`_ at Mozilla.
 
@@ -13,8 +14,9 @@ request.
 .. _`Firefox Test Engineering`: https://wiki.mozilla.org/TestEngineering
 .. _`Webdev Bootcamp`: https://mozweb.readthedocs.io/
 
+****************
 Building locally
-----------------
+****************
 The instructions below assume you have Python and `pip`_ installed. It is also
 strongly recommended that you create and activate a `virtualenv`_ first.
 
@@ -34,9 +36,9 @@ changed.
 .. _pip: https://pip.pypa.io/
 .. _virtualenv: https://virtualenv.pypa.io/
 
+*********
 Licensing
----------
-
+*********
 Feel free to fork this repo or adapt its work for your own needs. All work
 is licensed under a `Creative Commons Attribution`_.
 

--- a/guide/accounts.rst
+++ b/guide/accounts.rst
@@ -1,12 +1,14 @@
+########
 Accounts
-========
+########
 
 We use a few websites/services/applications to manage our test-automation and infrastructure code, bugs, test cases, etc., and while it is possible to
 get by without signing up for these sites, it's *strongly* recommended that
 you create accounts on these websites.
 
+******
 GitHub
-------
+******
 
 Many Firefox Test Engineering projects are hosted on GitHub_. GitHub provides hosting for our
 source code, as well as tools we use for collaboration and code review. GitHub
@@ -28,8 +30,9 @@ for guides on the basics of using Git and GitHub.
 .. _GitHub help site: https://help.github.com/
 
 
+********
 Bugzilla
---------
+********
 
 Bugzilla_ is the issue-tracking system that the entire Mozilla Project uses.
 Many of our projects use Bugzilla to keep track of any planned
@@ -57,28 +60,34 @@ new employees get this permission automatically; there's no need to ask for it.
 .. _Bugzilla: https://bugzilla.mozilla.org/
 .. _`Bugzilla Permissions Page`: https://bugzilla.mozilla.org/page.cgi?id=get_permissions.html
 
+#######################
 Limited Access Accounts
-=======================
+#######################
 Our team also uses a number of services which are accessible only with special accounts and/or permissions. If you're under an `NDA <https://wiki.mozilla.org/NDA>`_ you may ask your mentor or manager for access.
 
+***************
 fx-test-pubkeys
----------------
+***************
 Used to keep our public keys, which we use for access control/authentication in our AWS' EC2 environments/instances.  Please follow the instructions at https://github.com/mozilla-services/fx-test-pubkeys to generate and upload yours.
 
+*************************
 Amazon Web Services (AWS)
--------------------------
+*************************
 AWS is currently used for much of our server and infrastructure testing. In the future it will likely hold a lot more of our test automation.
 
 You will very likely, at some point (sooner, rather than later) need a Mozilla-privileged AWS account.  Please follow these `instructions on Mana <https://mana.mozilla.org/wiki/display/SVCOPS/Requesting+A+Dev+IAM+account+from+Cloud+Operations>`_ to get one.
 
+********
 LastPass
---------
+********
 We use LastPass to securely share miscellaneous credentials (usernames/passwords/API keys).  Please follow the instructions  https://mana.mozilla.org/wiki/display/TestEngineering/LastPass to request and use an account with your Mozilla email address.
 
+*******
 Jenkins
--------
+*******
 Jenkins is used for running our test automation. It is in the process of being moved into AWS.
 
+********
 TestRail
---------
+********
 `TestRail <https://wiki.mozilla.org/TestEngineering/Testrail>`_ is being set up for use as a test case manager. In the future it will be more accessible and visible to community members.

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -1,5 +1,6 @@
+#####################
 New Contributor Guide
-=====================
+#####################
 
 First things first: Welcome to Mozilla! We're glad to have you here, whether
 you're considering volunteering as a contributor or are employed by Mozilla.
@@ -25,8 +26,9 @@ Let's get started!
    accounts
    software
 
+##################
 New Employee Guide
-==================
+##################
 
 Welcome to the New Employee Guide - hopefully you've already gone through, or are familiar with tools, accounts, processes, etc. in our New Contributor Guide.  An additional resource to familiarize yourself with is our `Firefox Test Engineering <https://mana.mozilla.org/wiki/display/TestEngineering>`_ space on Mana.
 

--- a/guide/projects.rst
+++ b/guide/projects.rst
@@ -1,18 +1,20 @@
+#################
 Finding a Project
-=================
+#################
 
 Before you can contribute to Mozilla, you need to find a project that you're
 interested in contributing to. We currently maintain a `list of
 projects`_ on Service Book.
 
-You may also browse all of the open GitHub Issues for our projects. The `Firefox Test Engineering Dashboard`_ lists 
-open Issues, just make sure to find one that no one else is working on. 
+You may also browse all of the open GitHub Issues for our projects. The `Firefox Test Engineering Dashboard`_ lists
+open Issues, just make sure to find one that no one else is working on.
 
 .. _list of projects: https://servicebook.stage.mozaws.net/info
 .. _Firefox Test Engineering Dashboard: http://mozilla.github.io/fxtest-dashboard/#/issues
 
-Getting set up
---------------
+**************
+Getting Set Up
+**************
 
 Once you've identified the project you want to work on, you should get the
 test automation running locally. All projects have (or should have) a README
@@ -21,8 +23,9 @@ documentation that does. If you haven't already, you will want to review the `Ne
 
 .. _New Contributor Guide:  http://firefox-test-engineering.readthedocs.io/en/latest/guide/index.html
 
-Find a mentor
--------------
+*************
+Find a Mentor
+*************
 
 You may also find it useful to find someone who is working on or responsible
 for the project you want to contribute to and asking if they can help you find
@@ -31,8 +34,9 @@ speaking, the project page should have this information. If it
 doesn't, try looking through the commit log of the source code to see
 who has been writing code for the project recently.
 
-How to contribute
------------------
+*****************
+How to Contribute
+*****************
 
 Once you're set up to work on a project, you'll have to find a task to work on
 and get coding! Each project should have some information on where their tasks

--- a/guide/software.rst
+++ b/guide/software.rst
@@ -1,5 +1,6 @@
+##################
 Software and Tools
-==================
+##################
 
 The software you'll need to download and install on your computer in order to
 contribute varies between projects; please refer to the documentation for the
@@ -8,8 +9,9 @@ project you want to contribute to for details.
 The following information is a generic description of software or tools that
 you'll most likely need regardless of the project you work on.
 
+*************************************************
 Operating Systems: Windows, Linux, or macOS/OS X?
---------------------------------------------------
+*************************************************
 
 Generally speaking, automation and test tools need to run on the
 platforms that are being tested. Linux and Mac are often used as
@@ -26,8 +28,9 @@ installed using the `Homebrew`_ package manager.
 .. _Homebrew: http://brew.sh/
 
 
+***
 Git
----
+***
 
 Git_ is a distributed version control system. It tracks the history of changes
 we make to our code, which allows us to see how the code has changed over time.
@@ -55,8 +58,9 @@ control systems, you might enjoy stepping through some or all of this
 .. _Git: https://git-scm.com/
 
 
+******************
 Load-Testing Tools
-------------------
+******************
 `Molotov <https://github.com/loads/molotov>`_ is used for writing and running load tests.
 
 `Ardere <https://github.com/loads/ardere>`_ is another tool (which replaces `loads-broker <https://github.com/loads/loads-broker>`_) to run load tests at scale/distributed.

--- a/guide/team.rst
+++ b/guide/team.rst
@@ -1,11 +1,13 @@
-About the Firefox Test Engineering team
-=======================================
+#######################################
+About the Firefox Test Engineering Team
+#######################################
 
 The Firefox Test Engineering team oversees the test automation, infrastructure, and manual testing for all of Firefox's services, sites, and apps that are external to the core browsers (and in some cases within the browsers as well).
 Our mission is to provide testing and tools to positively impact the quality of Mozilla websites and services.
 
+*****************
 How to Talk to Us
------------------
+*****************
 
 There are a few channels of communication for our group:
 
@@ -21,8 +23,9 @@ in return.
 
 .. _Firefox Test Engineering page on QMO: https://quality.mozilla.org/teams/test-engineering/
 
+**************
 Find a Mentor!
---------------
+**************
 
 It's also a good idea to find someone to mentor you as a new contributor.
 Having someone you can personally ask for help from is incredibly helpful in
@@ -33,8 +36,9 @@ coworker. If you're a volunteer, ask someone who works on the project you want
 to contribute to; if they cannot mentor you themselves, they should be able
 to direct you to someone who can.
 
+********************
 Turn on the Firehose
---------------------
+********************
 
 We are one team, part of a much bigger Mozilla project.  Here are some links:
 

--- a/guide/test_automation_process.rst
+++ b/guide/test_automation_process.rst
@@ -1,11 +1,13 @@
+#######################
 Test Automation Process
-=======================
+#######################
 
 While the details vary, there is a general framework for working on Firefox
 Test Engineering test automation projects. This document attempts to describe that process.
 
+*****************************
 Finding a Bug or GitHub Issue
------------------------------
+*****************************
 
 The first step is finding a good bug or GitHub Issue to work on.
 
@@ -23,8 +25,9 @@ The first step is finding a good bug or GitHub Issue to work on.
 .. _Firefox Test Engineering Dashboard: https://mozilla.github.io/fxtest-dashboard/#/issues
 .. _Bugs Ahoy:  https://www.joshmatthews.net/bugsahoy/
 
+************************
 Working on the Bug/Issue
-------------------------
+************************
 After claiming a Bug/Issue, you will submit your pull request with your work in a GitHub feature branch.
 
 Any mentors or project owners assigned to it will review your work and give constructive feedback and instructions for any changes that need to be made.  After the pull request is completed to satisfaction it will be merged into the project code.
@@ -33,7 +36,7 @@ The Bug/Issue will be resolved and closed after a successful code merge.
 
 
 Git and GitHub
-^^^^^^^^^^^^^^
+==============
 
 For projects using Git and GitHub, the process can be explained in more detail:
 
@@ -71,12 +74,13 @@ For projects using Git and GitHub, the process can be explained in more detail:
 .. _running test automation: https://developer.mozilla.org/en-US/docs/Mozilla/QA/Running_Web_QA_automated_tests
 
 
+******
 Mobile
-------
+******
 Mobile platforms such as iOS and Android are also an important part of our testing process. Testing is done on mobile platforms, and there are also mobile-specific tests.
 
 iOS
-^^^
+===
 Currently we use Apple's XCUITest framework in Swift. The test can be written and executed on
 Apple's XCode App, and you can see some of our `examples in the Firefox for iOS`_ repository. Some of the older
 Tests are in `KIFTest framework`_, but since they use undocumented Apple APIs, and XCUITest framework has been
@@ -97,15 +101,16 @@ You can learn more about basics of Swift and XCUITest from below websites:
 .. _UI Testing Cheat Sheet and Examples: http://masilotti.com/ui-testing-cheat-sheet/
 
 Android
-^^^^^^^
+=======
 A few of our Android mobile test-automation projects (particularly those written with Selenium WebDriver) use
 `Appium <http://appium.io/>`_.  For Firefox for Android testing automation that does not involve the testing
 of GeckoView, there is a `proof-of-concept test environment`_ using Appium.
 
 .. _proof-of-concept test environment: https://github.com/npark-mozilla/CG_Mobile_Test
 
-Next steps
-----------
+**********
+Next Steps
+**********
 
 At this point you should have all the information and tools you need to make
 your first contribution to Mozilla! Once you've submitted your work and gotten

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,6 @@
+########################
 Firefox Test Engineering
-========================
+########################
 Hello! Welcome to `Firefox Test Engineering`_, an informal
 introduction to how to work with our group.
 

--- a/reference/activedata.rst
+++ b/reference/activedata.rst
@@ -1,5 +1,6 @@
+##########################
 Test Results in ActiveData
-==========================
+##########################
 Our automated test results are publicly accessible via
 `ActiveData <https://wiki.mozilla.org/Auto-tools/Projects/ActiveData>`_, which
 allows us to determine areas the need attention. For example, we might want to
@@ -12,8 +13,9 @@ into ActiveData we need to generate structured logs and upload them to an
 Amazon S3 bucket. ActiveData scans this bucket, ingests the logs, and the
 results are then available for querying.
 
-Structured logs
----------------
+***************
+Structured Logs
+***************
 Many test suites at Mozilla use
 `mozlog <http://mozbase.readthedocs.io/en/latest/mozlog.html>`_ to generate
 structured logs. As ActiveData is already familiar with this format, it makes
@@ -36,8 +38,9 @@ ActiveData will be able to process. Here's an example of the output::
   {"status": "PASS", "pid": 92739, "test": "test_foo.py::test_bar", "action": "test_end", "component": "pytest", "source": "pytest", "time": 1489585072219, "thread": "MainThread"}
   {"pid": 92739, "action": "suite_end", "component": "pytest", "source": "pytest", "time": 1489585072594, "thread": "MainThread"}
 
+********
 Metadata
---------
+********
 In order to add context to the results we use the
 `pytest-metadata <https://pypi.python.org/pypi/pytest-metadata/>`_ plugin. This
 adds details on the platform, Python binary, pytest packages, and pytest
@@ -46,16 +49,17 @@ several continuous integrations servers, and we use this to associate results
 with a specific application under test. All of this data is added to the
 ``run_info`` in the ``suite_start`` message within the structured log.
 
+*******************
 Querying ActiveData
--------------------
+*******************
 You can use the
 `ActiveData Query Tool <https://activedata.allizom.org/tools/query.html>`_ to
 run queries and see the responses from ActiveData. The
 `getting started <https://github.com/klahnakoski/ActiveData/blob/dev/docs/GettingStarted.md>`_
 guide is a good place to start, however let's explore a couple of examples.
 
-Test durations
-~~~~~~~~~~~~~~
+Test Durations
+==============
 The following query will return the 90th percentile for test duration, grouped
 by test name and job:
 
@@ -78,8 +82,8 @@ longer against different environments, or across the board. This might
 highlight tests that are doing too much, or at least slowing down the feedback
 loop.
 
-Failing tests
-~~~~~~~~~~~~~
+Failing Tests
+=============
 The following query will return the total number of times each test has failed.
 
 .. code:: json
@@ -96,8 +100,9 @@ Note that this doesn't distinguish between the various outcomes that evaluate
 as a failure, so this is just wherever the outcome does not match the
 expectation.
 
-Plotting results
-----------------
+****************
+Plotting Results
+****************
 A useful way to visualize the results from ActiveData is to plot them on a
 chart. This can be achieved using a `Jupyter Notebook <https://jupyter.org/>`_,
 with pandas, NumPy, and matplotlib. If you have `Docker <http://docker.com/>`_
@@ -187,8 +192,9 @@ tweak the query and DataFrame, or try different types of charts.
 .. image:: ../images/outcomes.png
    :alt: Test failures by outcome in the past two weeks
 
-Known limitations
------------------
+*****************
+Known Limitations
+*****************
 Unfortunately, mozlog does not currently support Python 3. This means that any
 suite that produces structured logs for consumption by ActiveData is required
 to run on legacy Python.

--- a/reference/ci.rst
+++ b/reference/ci.rst
@@ -1,22 +1,24 @@
-======================
+######################
 Continuous Integration
-======================
+######################
 
+**********
 Production
-----------
+**********
 Our **production** Jenkins instance is available at
 https://qa-master.fxtest.jenkins.stage.mozaws.net/ and access is restricted according to
 this `documentation <https://mana.mozilla.org/wiki/display/TestEngineering/qa-master.fxtest.jenkins.stage.mozaws.net>`_.
 
+**************************
 Sandbox, aka "Dev Jenkins"
----------------------------
+**************************
 Our **sandbox** Jenkins instance is available at
 https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/ and requires a connection to
 the `Mozilla VPN`_. See the `Mozilla VPN documentation <https://mana.mozilla.org/wiki/display/TestEngineering/qa-preprod-master.fxtest.jenkins.stage.mozaws.net>`_
 for further information regarding this instance.
 
 Plugin Updates
-``````````````
+==============
 #. Whomever is able to respond and take action first, files a bug in Cloud Services | FXTest-Infra, cc:ing the rest of the core Jenkins/infra team, assigning the bug to themselves, and checking the “Security” checkbox at the bottom of the bug.  Include the Jenkins advisory text, with a link (like https://jenkins.io/security/advisory/2017-04-26/), the name of and link to the affected plugin(s), as well as the version to which you’ve upgraded Jenkins dev.  Please use `this Bugzilla template <https://bugzilla.mozilla.org/enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_severity=critical&bug_status=NEW&cc=ckolos%40mozilla.com&cc=oremj%40mozilla.com&cc=kthiessen%40mozilla.com&cc=stephen.donner%40gmail.com&cc=dave.hunt%40gmail.com&cf_blocking_fennec=---&cf_fx_iteration=---&cf_fx_points=---&cf_status_firefox55=---&cf_status_firefox56=---&cf_status_firefox57=---&cf_status_firefox_esr52=---&cf_tracking_firefox55=---&cf_tracking_firefox56=---&cf_tracking_firefox57=---&cf_tracking_firefox_esr52=---&cf_tracking_firefox_relnote=---&component=FXTest-infra&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-37=X&flag_type-4=X&flag_type-5=X&flag_type-607=X&flag_type-708=X&flag_type-721=X&flag_type-737=X&flag_type-781=X&flag_type-787=X&flag_type-800=X&flag_type-803=X&flag_type-846=X&flag_type-864=X&flag_type-914=X&flag_type-916=X&form_name=enter_bug&groups=cloud-services-security&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=--&product=Cloud%20Services&qa_contact=rpappalardo%40mozilla.com&rep_platform=Unspecified&target_milestone=---&version=unspecified>`_, to file.
 #. After filing, it's time to upgrade the plugin(s):
 #. Update Jenkins dev:
@@ -35,7 +37,7 @@ Plugin Updates
 #. If all goes well, follow the instructions for updating plugins on production Jenkins
 
 Plugin Addition
-```````````````
+===============
 #. Coordinate with and give peers a heads-up that you’re installing a new plugin on dev (and why)
 #. Install the plugin
 #. Restart Jenkins
@@ -50,8 +52,9 @@ Plugin Addition
 
 .. _Mozilla VPN: https://mana.mozilla.org/wiki/display/IT/Mozilla+VPN
 
+***************
 Ops-QA Pipeline
----------------
+***************
 **The current flow for a project integrated into the Cloud Ops deploy pipeline is as follows:**
 
 #. A tagged or pushed build from dev deploys to staging
@@ -66,7 +69,8 @@ Ops-QA Pipeline
 #. File a bug (example: `bug 1384404 <https://bugzilla.mozilla.org/show_bug.cgi?id=1384404>`_), in the most-appropriate component for your project, under the Cloud Services product, requesting Ops enable your jobs in their pipeline
 #. Next, from Ops' side, there is a `qaTest.groovy file <https://github.com/mozilla-services/cloudops-deployment/blob/c6a09fa1a62d1cddf3a3b560e92aca55a497d0d4/libs/pipeline/vars/qaTest.groovy#L13>`_ which calls `run_jenkins_job <https://github.com/mozilla-services/cloudops-deployment/blob/9626ef442346913733b2f14e11d490750d481411/bin/run_jenkins_job>`_, which, in turn, authenticates with QA (prod) Jenkins, and will run /job/${project}.${envName}
 
-Build notifications
--------------------
+*******************
+Build Notifications
+*******************
 
 Notifications can differ between projects, however typically whenever a build fails a notification is sent to the `fte-ci <https://groups.google.com/a/mozilla.com/forum/#!forum/fte-ci>`_ group. When the result of a build changes, a notification is sent to the #fx-test-alerts IRC channel on irc.mozilla.org.

--- a/reference/conventions.rst
+++ b/reference/conventions.rst
@@ -1,31 +1,33 @@
-==================
+##################
 Common Conventions
-==================
-The following are some hopefully-helpful pointers to common conventions we're using across *most* automation projects.  Their adoption aims to make automation easily repeatable, runnable, more reliable, and with clearer output.  This list is neither exhaustive nor authoritative, but we strive to keep it as up-to-date and relevant as possible. 
+##################
+The following are some hopefully-helpful pointers to common conventions we're using across *most* automation projects.  Their adoption aims to make automation easily repeatable, runnable, more reliable, and with clearer output.  This list is neither exhaustive nor authoritative, but we strive to keep it as up-to-date and relevant as possible.
 
+*************
 Code Coverage
--------------
+*************
 **Purpose:** Particularly relevant for our Python packages (which are used themselves in other testing projects and development repos), quite a few of our projects have implemented `Coveralls <https://coveralls.io>`_ code-coverage/analysis tool.
 
 For a real-world example of code removal that Coveralls caught, see https://github.com/mozilla/FoxPuppet/pull/162#issuecomment-373110700
 
+***********************************
 Dependencies + Virtual Environments
------------------------------------
+***********************************
 
 pyup
-~~~~~~~
+====
 **Purpose:** `pyup.io <https://pyup.io>`_ helps us manage updating our dependencies and requirements.
 
 There are a few scenarios for its use:
 
 * Test suite lives in a separate directory within project repo
- - `Example <https://github.com/mozilla-services/socorro/blob/3232f5e420fd7e5b80fa456c8f4c583b58ef1fbb/.pyup.yml>`_ from Socorro
- - `Example <https://github.com/mozilla-services/go-bouncer/blob/86e9b428eee25e1d708935397da884f99f9be051/.pyup.yml>`_ from Bouncer
+  - `Example <https://github.com/mozilla-services/socorro/blob/3232f5e420fd7e5b80fa456c8f4c583b58ef1fbb/.pyup.yml>`_ from Socorro
+  - `Example <https://github.com/mozilla-services/go-bouncer/blob/86e9b428eee25e1d708935397da884f99f9be051/.pyup.yml>`_ from Bouncer
 * Self-contained test suite
- - `Example <https://github.com/mozilla/mozillians-tests/blob/44f8d87560576549e801493dfb4069723d2d1506/.pyup.yml>`_ from Mozillians
+  - `Example <https://github.com/mozilla/mozillians-tests/blob/44f8d87560576549e801493dfb4069723d2d1506/.pyup.yml>`_ from Mozillians
 
 pipenv
-~~~~~~
+======
 **Purpose:** We use `pipenv <https://docs.pipenv.org/>`_ for managing virtual environments and installing dependencies.
 
 Typically, we:
@@ -35,11 +37,12 @@ Typically, we:
 #. Ignore generating and using the Pipfile.lock `(Example) <https://github.com/Kinto/kinto-integration-tests/blob/67239fe202a94fd9dd6aec664497f8c8343c7e46/Dockerfile#L6>`_
 
 tox
-~~~
+===
 **Purpose:** We use `tox <https://tox.readthedocs.io>`_ to run tests using multiple Python versions, as it automagically takes care of their respective virtual environments.
 
+******
 Docker
-------
+******
 **Purpose:** We use `Docker <https://www.docker.com>`_ to help ensure consistent, portable builds, with dependency/environment control.
 
 In most cases, we build our Docker image directly from its **master** branch in GitHub, in any one (or combination) of the following: Travis CI, Circle CI, and Jenkins.
@@ -51,18 +54,21 @@ Typically, we use two (2) main files, for Docker:
 
 For both of these files, see the official docs at https://docs.docker.com/engine/reference/builder
 
+*******************
 Jenkins/Jenkinsfile
--------
+*******************
 We prefer tests running in Jenkins to use a Jenkinsfile (and Docker, as much as possible).
 
+*******
 Linting
--------
+*******
 **Purpose:** `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ and `flake8 <http://flake8.pycqa.org>`_.  Other considerations for specific linting are:
 
 #. `flake8-isort <https://pypi.python.org/pypi/flake8-isort>`_
 #. `flake8-docstrings <https://pypi.python.org/pypi/flake8-docstrings>`_
 #. `pylint <https://www.pylint.org/>`_
 
+*********
 Travis CI
----------
+*********
 **Purpose:** We use `Travis CI <https://www.travis-ci.org/>`_ for linting pull requests/commits.

--- a/reference/git_github.rst
+++ b/reference/git_github.rst
@@ -1,5 +1,6 @@
+##############
 Git and GitHub
-==============
+##############
 
 The sections below describe some Firefox Test Engineering best practices for
 using Git and GitHub. For more general information on Git here is a link to
@@ -7,22 +8,25 @@ using Git and GitHub. For more general information on Git here is a link to
 
 .. _Good Resources: https://help.github.com/articles/good-resources-for-learning-git-and-github/
 
+******
 Issues
-------
+******
 You can find an issue to work on by going to the
 `Firefox Test Engineering Dashboard`_. Any unclaimed Issue is available to you
 to work on. You can find out more about our process in the :doc:`../guide/index`.
 
 .. _Firefox Test Engineering Dashboard: https://mozilla.github.io/fxtest-dashboard/#/issues
 
+***************
 Commit Messages
----------------
+***************
 
 See `Tim Pope's blog post on Git commit messages
 <http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_.
 
+****************
 Rebasing Commits
-----------------
+****************
 
 While projects vary in their opinions on whether merge commits should be
 avoided or not, it is generally a good idea to rebase a feature branch before
@@ -52,8 +56,9 @@ easier, and are recommended for all pull requests.
              sure no one else is using, such as feature branches on your
              personal fork.
 
+******************************************
 Owners and the Mozilla GitHub Organization
-------------------------------------------
+******************************************
 See the `GitHub page on wiki.mozilla.org <https://wiki.mozilla.org/Github>`_
 for information on the Mozilla organization on GitHub or anything that requires
 owner access for the organization.

--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -1,5 +1,6 @@
+########
 Glossary
-========
+########
 
 At Mozilla, we use a lot of special terms that mean specific, non-obvious
 things to those who aren't familiar with them. This

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -1,5 +1,6 @@
+#########
 Reference
-=========
+#########
 
 This is where all the useful information goes that doesn't fit into the
 :doc:`/guide/index`.

--- a/reference/irc-bot.rst
+++ b/reference/irc-bot.rst
@@ -1,5 +1,6 @@
+#######
 IRC Bot
-=======
+#######
 
 We have a chat bot in our IRC channel providing useful features such as
 notifications or new issues, pull requests and pushes to our GitHub

--- a/reference/pypom.rst
+++ b/reference/pypom.rst
@@ -1,5 +1,6 @@
+#####
 PyPOM
-=====
+#####
 
 PyPOM, or Python Page Object Model, is a Python library that provides a base
 page object model for use with Selenium functional tests.

--- a/reference/python-style.rst
+++ b/reference/python-style.rst
@@ -1,12 +1,14 @@
+##################
 Python Style Guide
-==================
+##################
 
 This document is a brief set of guidelines for writing Python code at
 Mozilla. Individual projects may override these rules; make sure you
 know the standards for your project!
 
+******************
 General Guidelines
-------------------
+******************
 - Follow `PEP 8`_.
 - Check your code against a linting tool. flake8_ is highly recommended for
   this.
@@ -14,8 +16,9 @@ General Guidelines
 .. _PEP 8: https://www.python.org/dev/peps/pep-0008/
 .. _flake8: https://flake8.readthedocs.io/
 
+*****************
 Import Statements
------------------
+*****************
 
 We expand on `PEP 8`_'s suggestions for import statements. These greatly improve
 one's ability to ascertain what is and isn't available in a given file.
@@ -100,8 +103,9 @@ Good::
     def my_code():
         foo.you()  # oh you...
 
-Whitespace matters
-------------------
+******************
+Whitespace Matters
+******************
 
 * Use 4 spaces, not 2---it increases legibility considerably.
 * Never use tabs---history has shown that we cannot handle them.

--- a/reference/testing.rst
+++ b/reference/testing.rst
@@ -1,5 +1,6 @@
+#######
 Testing
-=======
+#######
 
 Testing is a very important part of the development process. It allows us to
 verify the functionality of our projects as well as judge the quality of our
@@ -15,8 +16,9 @@ At Mozilla, we have multiple ways of testing our code, including:
 - Manual testing, which is performed by a human and involves verifying features
   work as expected and exploratory tests.
 
-Assessing and managing risk
----------------------------
+***************************
+Assessing and Managing Risk
+***************************
 
 The end goal of testing is to manage the risk of something going wrong with
 your project. To this end, one of the first steps you should take is to assess
@@ -39,8 +41,9 @@ included Django application. For Node-based projects, they normally live in
 a directory named ``test`` or ``tests`` at the root of the repository. Refer to
 your project's documentation for more details.
 
-End-to-end tests
-----------------
+****************
+End-to-End Tests
+****************
 
 End-to-end tests simulates how your project will be used by users and verifies
 that it behaves as expected. This is most commonly applied to websites, where
@@ -51,8 +54,9 @@ the various :doc:`server environments <servers>`.
 
 .. _Selenium: http://www.seleniumhq.org/projects/webdriver/
 
-Manual testing
---------------
+**************
+Manual Testing
+**************
 
 Manual testing is good old-fashioned human-powered testing, where a living,
 breathing human uses your project and checks for any errors. Typically this is
@@ -62,14 +66,15 @@ exploratory testing.
 In addition to writing automated tests, you almost certainly should be manually
 testing any changes you make to a project.
 
-Testing tools
--------------
+*************
+Testing Tools
+*************
 
 The following is a non-exhaustive, possibly-out-of-date list of tools and
 libraries that may aid you in testing your projects.
 
 General
-^^^^^^^
+=======
 
 - Jenkins_ is a continuous integration server that builds and/or tests software
   projects continuously.
@@ -81,7 +86,7 @@ General
 .. _Travis CI: https://travis-ci.org/
 
 Python
-^^^^^^
+======
 
 - pytest_ is a highly recommended testing library for Python, with a great
   plugin ecosystem. Some common plugins we're using include
@@ -103,7 +108,7 @@ Python
 .. _pytest-bugzilla-notifier: https://pypi.python.org/pypi/pytest-bugzilla-notifier/0.1.2
 
 Node / JavaScript
-^^^^^^^^^^^^^^^^^
+=================
 
 - Mocha_ is a framework for running tests on node.js and in the browser.
 - Chai_ is an assertion library with many interfaces to accomodate different

--- a/reference/treeherder.rst
+++ b/reference/treeherder.rst
@@ -1,20 +1,23 @@
+##########################
 Test Results in Treeherder
-==========================
+##########################
 `Treeherder <https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder>`_
 is Mozilla's reporting dashboard for checkins, builds, and test results. Our
 automated test results are published to Treeherder via
 `Pulse <https://wiki.mozilla.org/Auto-tools/Projects/Pulse>`_.
 
+***********************
 Submitting from Jenkins
-~~~~~~~~~~~~~~~~~~~~~~~
+***********************
 To submit results from Jenkins you will need to write your job as a
 `declarative pipeline <https://jenkins.io/doc/book/pipeline/>`_ using our
 fxtest `shared library <https://github.com/mozilla/fxtest-jenkins-pipeline>`_.
 See `the documentation <https://github.com/mozilla/fxtest-jenkins-pipeline#submittotreeherder>`_
 for more information.
 
+*****************************
 Viewing results in Treeherder
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*****************************
 To view the results for a particular project, open
 `Treeherder <https://treeherder.mozilla.org/>`_ and select the appropriate
 repository from the menu. Most of our projects will be found within the

--- a/resources/index.rst
+++ b/resources/index.rst
@@ -1,5 +1,6 @@
+#########
 Resources
-=========
+#########
 
 Useful resources for further reading and learning.
 

--- a/resources/video.rst
+++ b/resources/video.rst
@@ -1,5 +1,6 @@
+######
 Videos
-======
+######
 
 * `Mozilla Onboarding <https://air.mozilla.org/channels/onboarding/>`_ - things that you'll be using at Mozilla.
 * `Mozilla QA on YouTube <https://www.youtube.com/channel/UCGMIgnRifGGX0iEmpHpRvkw>`_


### PR DESCRIPTION
Modified header markup to follow http://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html#headings

Reason: the header tags are generated by relative hierarchy. If the highest header on a page is marked with `=======`, then that will be generated into an `h1` tag.

The top-most header on a page should always start with `####`; not doing so prevents being able to create smaller headers, e.g. `h4`, `h5`, and so on.

Also modified capitalization in some headers for consistency.